### PR TITLE
changed the default feedback url to point to github

### DIFF
--- a/javascriptAndCss/feedback.js
+++ b/javascriptAndCss/feedback.js
@@ -1,3 +1,3 @@
 function giveFeedback(){
-	 window.open("https://sems.uni-rostock.de/trac/stats-website/newticket?from=" + window.location.href)
+	 window.open("https://github.com/SemsProject/MOST/issues/new?body=%0A%0A___%0AI%20came%20from%20the%20MOST%20website%20through%20the%20feedback%20button")
 }


### PR DESCRIPTION
The feedback should go to GitHub instead of the SEMS trac...